### PR TITLE
Fix fflonk compile issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,10 @@ polkavm-derive-impl-macro = { git = "https://github.com/andor0/polkavm.git", bra
 polkavm-linker            = { git = "https://github.com/andor0/polkavm.git", branch = "andor0/remove-userdata", default-features = false }
 polkavm-linux-raw         = { git = "https://github.com/andor0/polkavm.git", branch = "andor0/remove-userdata", default-features = false }
 
+# hotfix for https://github.com/paritytech/polkadot-sdk/issues/7653
+[patch.'https://github.com/w3f/fflonk']
+fflonk = { git = "https://www.github.com/w3f/fflonk", rev = "be95d4c971b1d15b5badfc06ff13f5c07987d484" }
+
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)', 'cfg(polkavm_dev_debug_zygote)'] }
 


### PR DESCRIPTION
`main` branch fails to compile with:
```sh
    Blocking waiting for file lock on package cache
    Updating git repository `https://github.com/w3f/fflonk`
error: no matching package named `fflonk` found
location searched: Git repository https://github.com/w3f/fflonk
required by package `ring v0.1.0 (https://github.com/w3f/ring-proof?rev=665f5f5#665f5f51)`
    ... which satisfies git dependency `ring` (locked to 0.1.0) of package `bandersnatch_vrfs v0.0.4 (https://github.com/w3f/ring-vrf?rev=0fef826#0fef8266)`
```
using the latest stable toolchain