### PR TITLE
Actually set slot duration to 100ms

### DIFF
--- a/runtime/src/configs/mod.rs
+++ b/runtime/src/configs/mod.rs
@@ -95,20 +95,12 @@ impl frame_system::Config for Runtime {
     type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
-pub struct MinimumPeriodTimes<T>(core::marker::PhantomData<T>);
-
-impl<T: pallet_timestamp::Config> Get<T::Moment> for MinimumPeriodTimes<T> {
-    fn get() -> T::Moment {
-        <T as pallet_timestamp::Config>::MinimumPeriod::get()
-    }
-}
-
 impl pallet_aura::Config for Runtime {
     type AuthorityId = SpinId;
     type DisabledValidators = ();
     type MaxAuthorities = ConstU32<32>;
     type AllowMultipleBlocksPerSlot = ConstBool<false>;
-    type SlotDuration = MinimumPeriodTimes<Runtime>;
+    type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Runtime>;
 }
 
 impl pallet_grandpa::Config for Runtime {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -66,7 +66,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 100,
+    spec_version: 101,
     impl_version: 1,
     apis: apis::RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
tldr: our slot duration is actually [set](https://github.com/QuantumFusion-network/qf-solochain/blob/main/runtime/src/configs/mod.rs#L111) to 50 ms, not 100 ms. 

Instead of [having](https://github.com/paritytech/polkadot-sdk/blob/master/templates/solochain/runtime/src/configs/mod.rs#L98) `Timestamp::MinimumPeriod * 2` slot duration, we [have](https://github.com/QuantumFusion-network/qf-solochain/blob/main/runtime/src/configs/mod.rs#L102) [`Timestamp::MinimumPeriod`](https://github.com/QuantumFusion-network/qf-solochain/blob/main/runtime/src/configs/mod.rs#L130).

this is most probably the cause for inconsistent block times on devnet, i.e it's too short amount of time so nodes skip some slots. However, when run locally, block times are consistent even with 50 ms. So, we should probably improve hardware and also apply this change

