### PR TITLE
Use release binary in actions and docker 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build, Release, and Publish Docker
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   build_binary:
@@ -40,7 +40,7 @@ jobs:
       - name: Build Project
         run: |
           make vendor-clone
-          make qf-node
+          make qf-node-release
 
       - name: Prepare artifacts
         run: |

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -23,7 +23,7 @@ RUN git clone https://github.com/QuantumFusion-network/qf-solochain.git
 
 WORKDIR /opt/qf-solochain
 RUN make vendor-clone
-RUN make qf-node
+RUN make qf-node-release
 RUN rm -rf /opt/qf-solochain/target
 
 FROM --platform=linux/${BUILD_ARCH} debian:bullseye-slim

--- a/docker/Dockerfile.qfnode
+++ b/docker/Dockerfile.qfnode
@@ -24,7 +24,7 @@ RUN git clone https://github.com/QuantumFusion-network/qf-solochain.git
 
 WORKDIR /opt/qf-solochain
 RUN make vendor-clone
-RUN make qf-node -j 8
+RUN make qf-node-release -j 8
 
 FROM --platform=linux/${BUILD_ARCH} debian:bullseye-slim
 

--- a/docker/Dockerfile.x86_64
+++ b/docker/Dockerfile.x86_64
@@ -24,7 +24,7 @@ RUN git clone https://github.com/QuantumFusion-network/qf-solochain.git
 
 WORKDIR /opt/qf-solochain
 RUN make vendor-clone
-RUN make qf-node
+RUN make qf-node-release
 
 FROM --platform=linux/${BUILD_ARCH} debian:bullseye-slim
 


### PR DESCRIPTION
weird why we are not using [it](https://nnethercote.github.io/perf-book/build-configuration.html#release-builds) in the first place