### PR TITLE
Return back submodules tracking in `./vendor/`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,4 @@ target/
 **/*.rs.bk
 *.polkavm
 
-vendor/
 output/


### PR DESCRIPTION
Ignoring submodule destination directory disables its content downloading by git.

```console
$ git clone --recursive git@github.com:QuantumFusion-network/qf-solochain.git
Cloning into 'qf-solochain'...
...
Resolving deltas: 100% (978/978), done.

$ ls qf-solochain/vendor
README.md

$
```