### PR TITLE
Make session length configurable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,4 +5,3 @@
 [submodule "vendor/polkadot-sdk"]
 	path = vendor/polkadot-sdk
 	url = https://github.com/QuantumFusion-network/polkadot-sdk
-	rev = "3793fc3444e28d309e67513fda5afe153a2aa928"

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,4 @@
 [submodule "vendor/polkadot-sdk"]
 	path = vendor/polkadot-sdk
 	url = https://github.com/QuantumFusion-network/polkadot-sdk
+	rev = "3793fc3444e28d309e67513fda5afe153a2aa928"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9545,6 +9545,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-spin"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "qfp-consensus-spin",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-spin-polkadot"
 version = "0.1.0"
 dependencies = [
@@ -12659,6 +12676,7 @@ dependencies = [
  "pallet-grandpa",
  "pallet-qf-polkavm",
  "pallet-qf-polkavm-dev",
+ "pallet-spin",
  "pallet-sudo",
  "pallet-timestamp",
  "pallet-transaction-payment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9546,7 +9546,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-spin"
-version = "1.0.0"
+version = "0.0.1"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12670,7 +12670,6 @@ dependencies = [
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
- "pallet-aura",
  "pallet-balances",
  "pallet-faucet",
  "pallet-grandpa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ pallet-faucet = { path = "pallets/faucet", default-features = false }
 pallet-qf-polkavm = { path = "pallets/qf-polkavm", default-features = false }
 pallet-qf-polkavm-dev = { path = "pallets/qf-polkavm-dev", default-features = false }
 pallet-spin-polkadot = { path = "pallets/spin-polkadot", default-features = false }
+pallet-spin = { path = "pallets/spin", default-features = false }
 sp-api = { path = "vendor/polkadot-sdk/substrate/primitives/api", default-features = false }
 sp-keystore = { path = "vendor/polkadot-sdk/substrate/primitives/keystore", default-features = false }
 sp-application-crypto = { path = "vendor/polkadot-sdk/substrate/primitives/application-crypto", default-features = false }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -106,7 +106,7 @@ fn testnet_genesis(
             // Configure endowed accounts with initial balance of 1 << 63.
             "balances": endowed_accounts.iter().cloned().map(|k| (k, 1u64 << 63)).collect::<Vec<_>>(),
         },
-        "aura": {
+        "spin": {
             "authorities": initial_authorities.iter().map(|x| (x.0.clone())).collect::<Vec<_>>(),
         },
         "grandpa": {

--- a/pallets/spin/Cargo.toml
+++ b/pallets/spin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-spin"
-version = "1.0.0"
+version = "0.0.1"
 authors.workspace = true
 edition.workspace = true
 license = "Apache-2.0"

--- a/pallets/spin/Cargo.toml
+++ b/pallets/spin/Cargo.toml
@@ -1,0 +1,53 @@
+[package]
+name = "pallet-spin"
+version = "1.0.0"
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+homepage.workspace = true
+repository.workspace = true
+description = "SPIN consensus pallet"
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+codec = { features = ["derive", "max-encoded-len"], workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+pallet-timestamp = { workspace = true }
+scale-info = { features = ["derive"], workspace = true }
+sp-application-crypto = { workspace = true }
+qfp-consensus-spin = { workspace = true }
+sp-runtime = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true }
+sp-io = { workspace = true, default-features = true }
+
+[features]
+default = ["std"]
+std = [
+	"codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"pallet-timestamp/std",
+	"scale-info/std",
+	"sp-application-crypto/std",
+	"qfp-consensus-spin/std",
+	"sp-core/std",
+	"sp-io/std",
+	"sp-runtime/std",
+]
+try-runtime = [
+	"frame-support/try-runtime",
+	"frame-system/try-runtime",
+	"pallet-timestamp/try-runtime",
+	"sp-runtime/try-runtime",
+]

--- a/pallets/spin/README.md
+++ b/pallets/spin/README.md
@@ -1,1 +1,3 @@
-forked off from `pallet-aura` at commit [1dbaeba9044ef491847a8204da98cd9e74534cdb](https://github.com/paritytech/polkadot-sdk/tree/1dbaeba9044ef491847a8204da98cd9e74534cdb/substrate/frame/aura)
+### SPIN module
+
+Forked off from `pallet-aura` at commit [1dbaeba9044ef491847a8204da98cd9e74534cdb](https://github.com/paritytech/polkadot-sdk/tree/1dbaeba9044ef491847a8204da98cd9e74534cdb/substrate/frame/aura)

--- a/pallets/spin/README.md
+++ b/pallets/spin/README.md
@@ -1,0 +1,1 @@
+forked off from `pallet-aura` at commit [1dbaeba9044ef491847a8204da98cd9e74534cdb](https://github.com/paritytech/polkadot-sdk/tree/1dbaeba9044ef491847a8204da98cd9e74534cdb/substrate/frame/aura)

--- a/pallets/spin/src/lib.rs
+++ b/pallets/spin/src/lib.rs
@@ -1,19 +1,6 @@
-// This file is part of Substrate.
-
-// Copyright (C) Parity Technologies (UK) Ltd.
+// Copyright (C) Quantum Fusion Network, 2025.
+// Copyright (C) Parity Technologies (UK) Ltd., until 2025.
 // SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/pallets/spin/src/lib.rs
+++ b/pallets/spin/src/lib.rs
@@ -195,10 +195,7 @@ pub mod pallet {
             ensure_root(origin)?;
 
             // Ensure the session length is not zero.
-            ensure!(
-                !session_len.is_zero(),
-                "Session length must be greater than zero."
-            );
+            ensure!(!session_len.is_zero(), Error::<T>::SessionLengthZero);
 
             SessionLength::<T>::put(session_len);
 

--- a/pallets/spin/src/lib.rs
+++ b/pallets/spin/src/lib.rs
@@ -1,0 +1,413 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Aura Module
+//!
+//! - [`Config`]
+//! - [`Pallet`]
+//!
+//! ## Overview
+//!
+//! The Aura module extends Aura consensus by managing offline reporting.
+//!
+//! ## Interface
+//!
+//! ### Public Functions
+//!
+//! - `slot_duration` - Determine the Aura slot-duration based on the Timestamp module
+//!   configuration.
+//!
+//! ## Related Modules
+//!
+//! - [Timestamp](../pallet_timestamp/index.html): The Timestamp module is used in Aura to track
+//! consensus rounds (via `slots`).
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::{
+    BoundedSlice, BoundedVec, ConsensusEngineId, Parameter,
+    traits::{DisabledValidators, FindAuthor, Get, OnTimestampSet, OneSessionHandler},
+};
+use log;
+use sp_consensus_aura::{AURA_ENGINE_ID, AuthorityIndex, ConsensusLog, Slot};
+use sp_runtime::{
+    RuntimeAppPublic,
+    generic::DigestItem,
+    traits::{IsMember, Member, SaturatedConversion, Saturating, Zero},
+};
+
+mod mock;
+mod tests;
+
+pub use pallet::*;
+
+const LOG_TARGET: &str = "runtime::aura";
+
+/// A slot duration provider which infers the slot duration from the
+/// [`pallet_timestamp::Config::MinimumPeriod`] by multiplying it by two, to ensure
+/// that authors have the majority of their slot to author within.
+///
+/// This was the default behavior of the Aura pallet and may be used for
+/// backwards compatibility.
+pub struct MinimumPeriodTimesTwo<T>(core::marker::PhantomData<T>);
+
+impl<T: pallet_timestamp::Config> Get<T::Moment> for MinimumPeriodTimesTwo<T> {
+    fn get() -> T::Moment {
+        <T as pallet_timestamp::Config>::MinimumPeriod::get().saturating_mul(2u32.into())
+    }
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+
+    #[pallet::config]
+    pub trait Config: pallet_timestamp::Config + frame_system::Config {
+        /// The identifier type for an authority.
+        type AuthorityId: Member
+            + Parameter
+            + RuntimeAppPublic
+            + MaybeSerializeDeserialize
+            + MaxEncodedLen;
+        /// The maximum number of authorities that the pallet can hold.
+        type MaxAuthorities: Get<u32>;
+
+        /// A way to check whether a given validator is disabled and should not be authoring blocks.
+        /// Blocks authored by a disabled validator will lead to a panic as part of this module's
+        /// initialization.
+        type DisabledValidators: DisabledValidators;
+
+        /// Whether to allow block authors to create multiple blocks per slot.
+        ///
+        /// If this is `true`, the pallet will allow slots to stay the same across sequential
+        /// blocks. If this is `false`, the pallet will require that subsequent blocks always have
+        /// higher slots than previous ones.
+        ///
+        /// Regardless of the setting of this storage value, the pallet will always enforce the
+        /// invariant that slots don't move backwards as the chain progresses.
+        ///
+        /// The typical value for this should be 'false' unless this pallet is being augmented by
+        /// another pallet which enforces some limitation on the number of blocks authors can create
+        /// using the same slot.
+        type AllowMultipleBlocksPerSlot: Get<bool>;
+
+        /// The slot duration Aura should run with, expressed in milliseconds.
+        /// The effective value of this type should not change while the chain is running.
+        ///
+        /// For backwards compatibility either use [`MinimumPeriodTimesTwo`] or a const.
+        #[pallet::constant]
+        type SlotDuration: Get<<Self as pallet_timestamp::Config>::Moment>;
+    }
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(core::marker::PhantomData<T>);
+
+    #[pallet::hooks]
+    impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+        fn on_initialize(_: BlockNumberFor<T>) -> Weight {
+            if let Some(new_slot) = Self::current_slot_from_digests() {
+                let current_slot = CurrentSlot::<T>::get();
+
+                if T::AllowMultipleBlocksPerSlot::get() {
+                    assert!(current_slot <= new_slot, "Slot must not decrease");
+                } else {
+                    assert!(current_slot < new_slot, "Slot must increase");
+                }
+
+                CurrentSlot::<T>::put(new_slot);
+
+                if let Some(n_authorities) = <Authorities<T>>::decode_len() {
+                    let authority_index = *new_slot % n_authorities as u64;
+                    if T::DisabledValidators::is_disabled(authority_index as u32) {
+                        panic!(
+                            "Validator with index {:?} is disabled and should not be attempting to author blocks.",
+                            authority_index,
+                        );
+                    }
+                }
+
+                // TODO [#3398] Generate offence report for all authorities that skipped their
+                // slots.
+
+                T::DbWeight::get().reads_writes(2, 1)
+            } else {
+                T::DbWeight::get().reads(1)
+            }
+        }
+
+        #[cfg(feature = "try-runtime")]
+        fn try_state(_: BlockNumberFor<T>) -> Result<(), sp_runtime::TryRuntimeError> {
+            Self::do_try_state()
+        }
+    }
+
+    /// The current authority set.
+    #[pallet::storage]
+    pub type Authorities<T: Config> =
+        StorageValue<_, BoundedVec<T::AuthorityId, T::MaxAuthorities>, ValueQuery>;
+
+    /// The current slot of this block.
+    ///
+    /// This will be set in `on_initialize`.
+    #[pallet::storage]
+    pub type CurrentSlot<T: Config> = StorageValue<_, Slot, ValueQuery>;
+
+    #[pallet::genesis_config]
+    #[derive(frame_support::DefaultNoBound)]
+    pub struct GenesisConfig<T: Config> {
+        pub authorities: Vec<T::AuthorityId>,
+    }
+
+    #[pallet::genesis_build]
+    impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+        fn build(&self) {
+            Pallet::<T>::initialize_authorities(&self.authorities);
+        }
+    }
+}
+
+impl<T: Config> Pallet<T> {
+    /// Change authorities.
+    ///
+    /// The storage will be applied immediately.
+    /// And aura consensus log will be appended to block's log.
+    ///
+    /// This is a no-op if `new` is empty.
+    pub fn change_authorities(new: BoundedVec<T::AuthorityId, T::MaxAuthorities>) {
+        if new.is_empty() {
+            log::warn!(target: LOG_TARGET, "Ignoring empty authority change.");
+
+            return;
+        }
+
+        <Authorities<T>>::put(&new);
+
+        let log = DigestItem::Consensus(
+            AURA_ENGINE_ID,
+            ConsensusLog::AuthoritiesChange(new.into_inner()).encode(),
+        );
+        <frame_system::Pallet<T>>::deposit_log(log);
+    }
+
+    /// Initial authorities.
+    ///
+    /// The storage will be applied immediately.
+    ///
+    /// The authorities length must be equal or less than T::MaxAuthorities.
+    pub fn initialize_authorities(authorities: &[T::AuthorityId]) {
+        if !authorities.is_empty() {
+            assert!(
+                <Authorities<T>>::get().is_empty(),
+                "Authorities are already initialized!"
+            );
+            let bounded = <BoundedSlice<'_, _, T::MaxAuthorities>>::try_from(authorities)
+                .expect("Initial authority set must be less than T::MaxAuthorities");
+            <Authorities<T>>::put(bounded);
+        }
+    }
+
+    /// Return current authorities length.
+    pub fn authorities_len() -> usize {
+        Authorities::<T>::decode_len().unwrap_or(0)
+    }
+
+    /// Get the current slot from the pre-runtime digests.
+    fn current_slot_from_digests() -> Option<Slot> {
+        let digest = frame_system::Pallet::<T>::digest();
+        let pre_runtime_digests = digest.logs.iter().filter_map(|d| d.as_pre_runtime());
+        for (id, mut data) in pre_runtime_digests {
+            if id == AURA_ENGINE_ID {
+                return Slot::decode(&mut data).ok();
+            }
+        }
+
+        None
+    }
+
+    /// Determine the Aura slot-duration based on the Timestamp module configuration.
+    pub fn slot_duration() -> T::Moment {
+        T::SlotDuration::get()
+    }
+
+    /// Ensure the correctness of the state of this pallet.
+    ///
+    /// This should be valid before or after each state transition of this pallet.
+    ///
+    /// # Invariants
+    ///
+    /// ## `CurrentSlot`
+    ///
+    /// If we don't allow for multiple blocks per slot, then the current slot must be less than the
+    /// maximal slot number. Otherwise, it can be arbitrary.
+    ///
+    /// ## `Authorities`
+    ///
+    /// * The authorities must be non-empty.
+    /// * The current authority cannot be disabled.
+    /// * The number of authorities must be less than or equal to `T::MaxAuthorities`. This however,
+    ///   is guarded by the type system.
+    #[cfg(any(test, feature = "try-runtime"))]
+    pub fn do_try_state() -> Result<(), sp_runtime::TryRuntimeError> {
+        // We don't have any guarantee that we are already after `on_initialize` and thus we have to
+        // check the current slot from the digest or take the last known slot.
+        let current_slot =
+            Self::current_slot_from_digests().unwrap_or_else(|| CurrentSlot::<T>::get());
+
+        // Check that the current slot is less than the maximal slot number, unless we allow for
+        // multiple blocks per slot.
+        if !T::AllowMultipleBlocksPerSlot::get() {
+            frame_support::ensure!(
+                current_slot < u64::MAX,
+                "Current slot has reached maximum value and cannot be incremented further.",
+            );
+        }
+
+        let authorities_len =
+            <Authorities<T>>::decode_len().ok_or("Failed to decode authorities length")?;
+
+        // Check that the authorities are non-empty.
+        frame_support::ensure!(!authorities_len.is_zero(), "Authorities must be non-empty.");
+
+        // Check that the current authority is not disabled.
+        let authority_index = *current_slot % authorities_len as u64;
+        frame_support::ensure!(
+            !T::DisabledValidators::is_disabled(authority_index as u32),
+            "Current validator is disabled and should not be attempting to author blocks.",
+        );
+
+        Ok(())
+    }
+}
+
+impl<T: Config> sp_runtime::BoundToRuntimeAppPublic for Pallet<T> {
+    type Public = T::AuthorityId;
+}
+
+impl<T: Config> OneSessionHandler<T::AccountId> for Pallet<T> {
+    type Key = T::AuthorityId;
+
+    fn on_genesis_session<'a, I: 'a>(validators: I)
+    where
+        I: Iterator<Item = (&'a T::AccountId, T::AuthorityId)>,
+    {
+        let authorities = validators.map(|(_, k)| k).collect::<Vec<_>>();
+        Self::initialize_authorities(&authorities);
+    }
+
+    fn on_new_session<'a, I: 'a>(changed: bool, validators: I, _queued_validators: I)
+    where
+        I: Iterator<Item = (&'a T::AccountId, T::AuthorityId)>,
+    {
+        // instant changes
+        if changed {
+            let next_authorities = validators.map(|(_, k)| k).collect::<Vec<_>>();
+            let last_authorities = Authorities::<T>::get();
+            if last_authorities != next_authorities {
+                if next_authorities.len() as u32 > T::MaxAuthorities::get() {
+                    log::warn!(
+                        target: LOG_TARGET,
+                        "next authorities list larger than {}, truncating",
+                        T::MaxAuthorities::get(),
+                    );
+                }
+                let bounded = <BoundedVec<_, T::MaxAuthorities>>::truncate_from(next_authorities);
+                Self::change_authorities(bounded);
+            }
+        }
+    }
+
+    fn on_disabled(i: u32) {
+        let log = DigestItem::Consensus(
+            AURA_ENGINE_ID,
+            ConsensusLog::<T::AuthorityId>::OnDisabled(i as AuthorityIndex).encode(),
+        );
+
+        <frame_system::Pallet<T>>::deposit_log(log);
+    }
+}
+
+impl<T: Config> FindAuthor<u32> for Pallet<T> {
+    fn find_author<'a, I>(digests: I) -> Option<u32>
+    where
+        I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+    {
+        for (id, mut data) in digests.into_iter() {
+            if id == AURA_ENGINE_ID {
+                let slot = Slot::decode(&mut data).ok()?;
+                let author_index = *slot % Self::authorities_len() as u64;
+                return Some(author_index as u32);
+            }
+        }
+
+        None
+    }
+}
+
+/// We can not implement `FindAuthor` twice, because the compiler does not know if
+/// `u32 == T::AuthorityId` and thus, prevents us to implement the trait twice.
+#[doc(hidden)]
+pub struct FindAccountFromAuthorIndex<T, Inner>(core::marker::PhantomData<(T, Inner)>);
+
+impl<T: Config, Inner: FindAuthor<u32>> FindAuthor<T::AuthorityId>
+    for FindAccountFromAuthorIndex<T, Inner>
+{
+    fn find_author<'a, I>(digests: I) -> Option<T::AuthorityId>
+    where
+        I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
+    {
+        let i = Inner::find_author(digests)?;
+
+        let validators = Authorities::<T>::get();
+        validators.get(i as usize).cloned()
+    }
+}
+
+/// Find the authority ID of the Aura authority who authored the current block.
+pub type AuraAuthorId<T> = FindAccountFromAuthorIndex<T, Pallet<T>>;
+
+impl<T: Config> IsMember<T::AuthorityId> for Pallet<T> {
+    fn is_member(authority_id: &T::AuthorityId) -> bool {
+        Authorities::<T>::get().iter().any(|id| id == authority_id)
+    }
+}
+
+impl<T: Config> OnTimestampSet<T::Moment> for Pallet<T> {
+    fn on_timestamp_set(moment: T::Moment) {
+        let slot_duration = Self::slot_duration();
+        assert!(
+            !slot_duration.is_zero(),
+            "Aura slot duration cannot be zero."
+        );
+
+        let timestamp_slot = moment / slot_duration;
+        let timestamp_slot = Slot::from(timestamp_slot.saturated_into::<u64>());
+
+        assert_eq!(
+            CurrentSlot::<T>::get(),
+            timestamp_slot,
+            "Timestamp slot must match `CurrentSlot`. This likely means that the configured block \
+			time in the node and/or rest of the runtime is not compatible with Aura's \
+			`SlotDuration`",
+        );
+    }
+}

--- a/pallets/spin/src/mock.rs
+++ b/pallets/spin/src/mock.rs
@@ -1,0 +1,113 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Test utilities
+
+#![cfg(test)]
+
+use crate as pallet_aura;
+use frame_support::{
+    derive_impl, parameter_types,
+    traits::{ConstU32, ConstU64, DisabledValidators},
+};
+use sp_consensus_aura::{ed25519::AuthorityId, AuthorityIndex};
+use sp_runtime::{testing::UintAuthorityId, BuildStorage};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+const SLOT_DURATION: u64 = 2;
+
+frame_support::construct_runtime!(
+    pub enum Test
+    {
+        System: frame_system,
+        Timestamp: pallet_timestamp,
+        Aura: pallet_aura,
+    }
+);
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+}
+
+impl pallet_timestamp::Config for Test {
+    type Moment = u64;
+    type OnTimestampSet = Aura;
+    type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
+    type WeightInfo = ();
+}
+
+parameter_types! {
+    static DisabledValidatorTestValue: Vec<AuthorityIndex> = Default::default();
+    pub static AllowMultipleBlocksPerSlot: bool = false;
+}
+
+pub struct MockDisabledValidators;
+
+impl MockDisabledValidators {
+    pub fn disable_validator(index: AuthorityIndex) {
+        DisabledValidatorTestValue::mutate(|v| {
+            if let Err(i) = v.binary_search(&index) {
+                v.insert(i, index);
+            }
+        })
+    }
+}
+
+impl DisabledValidators for MockDisabledValidators {
+    fn is_disabled(index: AuthorityIndex) -> bool {
+        DisabledValidatorTestValue::get()
+            .binary_search(&index)
+            .is_ok()
+    }
+
+    fn disabled_validators() -> Vec<u32> {
+        DisabledValidatorTestValue::get()
+    }
+}
+
+impl pallet_aura::Config for Test {
+    type AuthorityId = AuthorityId;
+    type DisabledValidators = MockDisabledValidators;
+    type MaxAuthorities = ConstU32<10>;
+    type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
+    type SlotDuration = ConstU64<SLOT_DURATION>;
+}
+
+fn build_ext(authorities: Vec<u64>) -> sp_io::TestExternalities {
+    let mut storage = frame_system::GenesisConfig::<Test>::default()
+        .build_storage()
+        .unwrap();
+    pallet_aura::GenesisConfig::<Test> {
+        authorities: authorities
+            .into_iter()
+            .map(|a| UintAuthorityId(a).to_public_key())
+            .collect(),
+    }
+    .assimilate_storage(&mut storage)
+    .unwrap();
+    storage.into()
+}
+
+pub fn build_ext_and_execute_test(authorities: Vec<u64>, test: impl FnOnce() -> ()) {
+    let mut ext = build_ext(authorities);
+    ext.execute_with(|| {
+        test();
+        Aura::do_try_state().expect("Storage invariants should hold")
+    });
+}

--- a/pallets/spin/src/mock.rs
+++ b/pallets/spin/src/mock.rs
@@ -19,13 +19,13 @@
 
 #![cfg(test)]
 
-use crate as pallet_aura;
+use crate as pallet_spin;
 use frame_support::{
     derive_impl, parameter_types,
     traits::{ConstU32, ConstU64, DisabledValidators},
 };
-use sp_consensus_aura::{ed25519::AuthorityId, AuthorityIndex};
-use sp_runtime::{testing::UintAuthorityId, BuildStorage};
+use qfp_consensus_spin::{AuthorityIndex, ed25519::AuthorityId};
+use sp_runtime::{BuildStorage, testing::UintAuthorityId};
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -36,7 +36,7 @@ frame_support::construct_runtime!(
     {
         System: frame_system,
         Timestamp: pallet_timestamp,
-        Aura: pallet_aura,
+        Spin: pallet_spin,
     }
 );
 
@@ -47,7 +47,7 @@ impl frame_system::Config for Test {
 
 impl pallet_timestamp::Config for Test {
     type Moment = u64;
-    type OnTimestampSet = Aura;
+    type OnTimestampSet = Spin;
     type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
     type WeightInfo = ();
 }
@@ -81,19 +81,22 @@ impl DisabledValidators for MockDisabledValidators {
     }
 }
 
-impl pallet_aura::Config for Test {
+pub(super) const DEFAULT_SESSION_LENGTH: u32 = 4;
+impl pallet_spin::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = AuthorityId;
     type DisabledValidators = MockDisabledValidators;
     type MaxAuthorities = ConstU32<10>;
     type AllowMultipleBlocksPerSlot = AllowMultipleBlocksPerSlot;
     type SlotDuration = ConstU64<SLOT_DURATION>;
+    type DefaultSessionLength = ConstU32<DEFAULT_SESSION_LENGTH>;
 }
 
 fn build_ext(authorities: Vec<u64>) -> sp_io::TestExternalities {
     let mut storage = frame_system::GenesisConfig::<Test>::default()
         .build_storage()
         .unwrap();
-    pallet_aura::GenesisConfig::<Test> {
+    pallet_spin::GenesisConfig::<Test> {
         authorities: authorities
             .into_iter()
             .map(|a| UintAuthorityId(a).to_public_key())
@@ -108,6 +111,6 @@ pub fn build_ext_and_execute_test(authorities: Vec<u64>, test: impl FnOnce() -> 
     let mut ext = build_ext(authorities);
     ext.execute_with(|| {
         test();
-        Aura::do_try_state().expect("Storage invariants should hold")
+        Spin::do_try_state().expect("Storage invariants should hold")
     });
 }

--- a/pallets/spin/src/mock.rs
+++ b/pallets/spin/src/mock.rs
@@ -1,20 +1,3 @@
-// This file is part of Substrate.
-
-// Copyright (C) Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //! Test utilities
 
 #![cfg(test)]

--- a/pallets/spin/src/tests.rs
+++ b/pallets/spin/src/tests.rs
@@ -1,0 +1,130 @@
+// This file is part of Substrate.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the module.
+
+#![cfg(test)]
+
+use super::pallet;
+use crate::mock::{build_ext_and_execute_test, Aura, MockDisabledValidators, System, Test};
+use codec::Encode;
+use frame_support::traits::OnInitialize;
+use sp_consensus_aura::{Slot, AURA_ENGINE_ID};
+use sp_runtime::{Digest, DigestItem};
+
+#[test]
+fn initial_values() {
+    build_ext_and_execute_test(vec![0, 1, 2, 3], || {
+        assert_eq!(pallet::CurrentSlot::<Test>::get(), 0u64);
+        assert_eq!(
+            pallet::Authorities::<Test>::get().len(),
+            Aura::authorities_len()
+        );
+        assert_eq!(Aura::authorities_len(), 4);
+    });
+}
+
+#[test]
+#[should_panic(
+    expected = "Validator with index 1 is disabled and should not be attempting to author blocks."
+)]
+fn disabled_validators_cannot_author_blocks() {
+    build_ext_and_execute_test(vec![0, 1, 2, 3], || {
+        // slot 1 should be authored by validator at index 1
+        let slot = Slot::from(1);
+        let pre_digest = Digest {
+            logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+        };
+
+        System::reset_events();
+        System::initialize(&42, &System::parent_hash(), &pre_digest);
+
+        // let's disable the validator
+        MockDisabledValidators::disable_validator(1);
+
+        // and we should not be able to initialize the block
+        Aura::on_initialize(42);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Slot must increase")]
+fn pallet_requires_slot_to_increase_unless_allowed() {
+    build_ext_and_execute_test(vec![0, 1, 2, 3], || {
+        crate::mock::AllowMultipleBlocksPerSlot::set(false);
+
+        let slot = Slot::from(1);
+        let pre_digest = Digest {
+            logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+        };
+
+        System::reset_events();
+        System::initialize(&42, &System::parent_hash(), &pre_digest);
+
+        // and we should not be able to initialize the block with the same slot a second time.
+        Aura::on_initialize(42);
+        Aura::on_initialize(42);
+    });
+}
+
+#[test]
+fn pallet_can_allow_unchanged_slot() {
+    build_ext_and_execute_test(vec![0, 1, 2, 3], || {
+        let slot = Slot::from(1);
+        let pre_digest = Digest {
+            logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+        };
+
+        System::reset_events();
+        System::initialize(&42, &System::parent_hash(), &pre_digest);
+
+        crate::mock::AllowMultipleBlocksPerSlot::set(true);
+
+        // and we should be able to initialize the block with the same slot a second time.
+        Aura::on_initialize(42);
+        Aura::on_initialize(42);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Slot must not decrease")]
+fn pallet_always_rejects_decreasing_slot() {
+    build_ext_and_execute_test(vec![0, 1, 2, 3], || {
+        let slot = Slot::from(2);
+        let pre_digest = Digest {
+            logs: vec![DigestItem::PreRuntime(AURA_ENGINE_ID, slot.encode())],
+        };
+
+        System::reset_events();
+        System::initialize(&42, &System::parent_hash(), &pre_digest);
+
+        crate::mock::AllowMultipleBlocksPerSlot::set(true);
+
+        Aura::on_initialize(42);
+        System::finalize();
+
+        let earlier_slot = Slot::from(1);
+        let pre_digest = Digest {
+            logs: vec![DigestItem::PreRuntime(
+                AURA_ENGINE_ID,
+                earlier_slot.encode(),
+            )],
+        };
+        System::initialize(&43, &System::parent_hash(), &pre_digest);
+        Aura::on_initialize(43);
+    });
+}

--- a/pallets/spin/src/tests.rs
+++ b/pallets/spin/src/tests.rs
@@ -1,20 +1,3 @@
-// This file is part of Substrate.
-
-// Copyright (C) Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //! Tests for the module.
 
 #![cfg(test)]

--- a/primitives/consensus-spin/src/inherents.rs
+++ b/primitives/consensus-spin/src/inherents.rs
@@ -6,7 +6,7 @@
 use sp_inherents::{Error, InherentData, InherentIdentifier};
 
 /// The SPIN inherent identifier.
-pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"auraslot";
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"spinslot";
 
 /// The type of the SPIN inherent.
 pub type InherentType = sp_consensus_slots::Slot;

--- a/primitives/consensus-spin/src/lib.rs
+++ b/primitives/consensus-spin/src/lib.rs
@@ -54,7 +54,7 @@ pub mod ed25519 {
 pub use sp_consensus_slots::{Slot, SlotDuration};
 
 /// The `ConsensusEngineId` of SPIN.
-pub const SPIN_ENGINE_ID: ConsensusEngineId = [b's', b'p', b'i', b'n'];
+pub const SPIN_ENGINE_ID: ConsensusEngineId = *b"spin";
 
 /// The index of an authority.
 pub type AuthorityIndex = u32;

--- a/primitives/consensus-spin/src/lib.rs
+++ b/primitives/consensus-spin/src/lib.rs
@@ -54,8 +54,7 @@ pub mod ed25519 {
 pub use sp_consensus_slots::{Slot, SlotDuration};
 
 /// The `ConsensusEngineId` of SPIN.
-/// TODO: this should be changed as well, once we have a fork of `pallet-aura`
-pub const SPIN_ENGINE_ID: ConsensusEngineId = [b'a', b'u', b'r', b'a'];
+pub const SPIN_ENGINE_ID: ConsensusEngineId = [b's', b'p', b'i', b'n'];
 
 /// The index of an authority.
 pub type AuthorityIndex = u32;

--- a/runtimes/qf-runtime/Cargo.toml
+++ b/runtimes/qf-runtime/Cargo.toml
@@ -29,7 +29,6 @@ frame-executive = { workspace = true }
 frame-metadata-hash-extension = { workspace = true }
 
 # frame pallets
-pallet-aura = { workspace = true }
 pallet-balances = { workspace = true }
 pallet-grandpa = { workspace = true }
 pallet-sudo = { workspace = true }
@@ -88,18 +87,14 @@ default = ["std"]
 std = [
 	"codec/std",
 	"scale-info/std",
-
 	"frame-executive/std",
 	"frame-metadata-hash-extension/std",
 	"frame-support/std",
 	"frame-system-benchmarking?/std",
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
-
 	"frame-benchmarking?/std",
 	"frame-try-runtime?/std",
-
-	"pallet-aura/std",
 	"pallet-balances/std",
 	"pallet-grandpa/std",
 	"pallet-sudo/std",
@@ -145,7 +140,6 @@ try-runtime = [
 	"frame-support/try-runtime",
 	"frame-system/try-runtime",
 	"frame-try-runtime/try-runtime",
-	"pallet-aura/try-runtime",
 	"pallet-balances/try-runtime",
 	"pallet-grandpa/try-runtime",
 	"pallet-sudo/try-runtime",

--- a/runtimes/qf-runtime/Cargo.toml
+++ b/runtimes/qf-runtime/Cargo.toml
@@ -74,8 +74,8 @@ pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 frame-benchmarking = { optional = true, workspace = true }
 frame-system-benchmarking = { optional = true, workspace = true }
 
-# The pallet in this template.
-# pallet-template = { workspace = true }
+# Spin
+pallet-spin = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { optional = true, workspace = true, default-features = true }
@@ -122,7 +122,7 @@ std = [
 	"sp-storage/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",
-
+	"pallet-spin/std",
 	"substrate-wasm-builder",
 ]
 

--- a/runtimes/qf-runtime/Cargo.toml
+++ b/runtimes/qf-runtime/Cargo.toml
@@ -103,7 +103,6 @@ std = [
 	"pallet-timestamp/std",
 	"pallet-transaction-payment-rpc-runtime-api/std",
 	"pallet-transaction-payment/std",
-
 	"sp-api/std",
 	"sp-block-builder/std",
 	"qfp-consensus-spin/std",
@@ -148,6 +147,8 @@ try-runtime = [
 	"pallet-timestamp/try-runtime",
 	"pallet-transaction-payment/try-runtime",
 	"sp-runtime/try-runtime",
+	# TODO: enable try-runtime for pallet-spin
+	"pallet-spin/try-runtime",
 ]
 
 # Enable the metadata hash generation.

--- a/runtimes/qf-runtime/src/apis.rs
+++ b/runtimes/qf-runtime/src/apis.rs
@@ -30,6 +30,8 @@ use frame_support::{
     weights::Weight,
 };
 use pallet_grandpa::AuthorityId as GrandpaId;
+use qfp_consensus_spin::SpinAuxData;
+use qfp_consensus_spin::sr25519::AuthorityId as SpinId;
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, crypto::KeyTypeId};
 use sp_runtime::{
@@ -38,13 +40,11 @@ use sp_runtime::{
     transaction_validity::{TransactionSource, TransactionValidity},
 };
 use sp_version::RuntimeVersion;
-use qfp_consensus_spin::SpinAuxData;
-use qfp_consensus_spin::sr25519::AuthorityId as SpinId;
 
 // Local module imports
 use super::{
-    AccountId, Aura, Balance, Block, Executive, Grandpa, InherentDataExt, Nonce, Runtime,
-    RuntimeCall, RuntimeGenesisConfig, SessionKeys, System, TransactionPayment, VERSION,
+    AccountId, Balance, Block, Executive, Grandpa, InherentDataExt, Nonce, Runtime, RuntimeCall,
+    RuntimeGenesisConfig, SessionKeys, Spin, System, TransactionPayment, VERSION,
 };
 
 impl_runtime_apis! {
@@ -115,13 +115,11 @@ impl_runtime_apis! {
 
     impl qfp_consensus_spin::SpinApi<Block, SpinId> for Runtime {
         fn slot_duration() -> qfp_consensus_spin::SlotDuration {
-            qfp_consensus_spin::SlotDuration::from_millis(Aura::slot_duration())
+            qfp_consensus_spin::SlotDuration::from_millis(Spin::slot_duration())
         }
 
         fn aux_data() -> SpinAuxData<SpinId> {
-            let authorities = pallet_aura::Authorities::<Runtime>::get().into_inner();
-
-            (authorities, crate::SESSION_LENGTH)
+            Spin::aux_data()
         }
     }
 

--- a/runtimes/qf-runtime/src/configs/mod.rs
+++ b/runtimes/qf-runtime/src/configs/mod.rs
@@ -35,19 +35,16 @@ use frame_support::{
 use frame_system::limits::{BlockLength, BlockWeights};
 use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier};
 use qfp_consensus_spin::sr25519::AuthorityId as SpinId;
-use sp_runtime::{
-    Perbill,
-    traits::One,
-};
+use sp_runtime::{Perbill, traits::One};
 use sp_version::RuntimeVersion;
 
 use crate::SESSION_LENGTH;
 
 // Local module imports
 use super::{
-    AccountId, Aura, Balance, Balances, Block, BlockNumber, EXISTENTIAL_DEPOSIT, Hash, Nonce,
-    PalletInfo, Runtime, RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason,
-    RuntimeOrigin, RuntimeTask, SLOT_DURATION, System, VERSION,
+    AccountId, Balance, Balances, Block, BlockNumber, EXISTENTIAL_DEPOSIT, Hash, Nonce, PalletInfo,
+    Runtime, RuntimeCall, RuntimeEvent, RuntimeFreezeReason, RuntimeHoldReason, RuntimeOrigin,
+    RuntimeTask, SLOT_DURATION, Spin, System, VERSION,
 };
 
 const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
@@ -95,12 +92,14 @@ impl frame_system::Config for Runtime {
     type MaxConsumers = frame_support::traits::ConstU32<16>;
 }
 
-impl pallet_aura::Config for Runtime {
+impl pallet_spin::Config for Runtime {
+    type RuntimeEvent = RuntimeEvent;
     type AuthorityId = SpinId;
     type DisabledValidators = ();
     type MaxAuthorities = ConstU32<32>;
     type AllowMultipleBlocksPerSlot = ConstBool<false>;
-    type SlotDuration = pallet_aura::MinimumPeriodTimesTwo<Runtime>;
+    type SlotDuration = pallet_spin::MinimumPeriodTimesTwo<Runtime>;
+    type DefaultSessionLength = ConstU32<SESSION_LENGTH>;
 }
 
 impl pallet_grandpa::Config for Runtime {
@@ -118,7 +117,7 @@ impl pallet_grandpa::Config for Runtime {
 impl pallet_timestamp::Config for Runtime {
     /// A timestamp: milliseconds since the unix epoch.
     type Moment = u64;
-    type OnTimestampSet = Aura;
+    type OnTimestampSet = Spin;
     type MinimumPeriod = ConstU64<{ SLOT_DURATION / 2 }>;
     type WeightInfo = ();
 }

--- a/runtimes/qf-runtime/src/lib.rs
+++ b/runtimes/qf-runtime/src/lib.rs
@@ -49,7 +49,7 @@ pub mod opaque {
 
 impl_opaque_keys! {
     pub struct SessionKeys {
-        pub aura: Spin,
+        pub spin: Spin,
         pub grandpa: Grandpa,
     }
 }

--- a/runtimes/qf-runtime/src/lib.rs
+++ b/runtimes/qf-runtime/src/lib.rs
@@ -49,7 +49,7 @@ pub mod opaque {
 
 impl_opaque_keys! {
     pub struct SessionKeys {
-        pub aura: Aura,
+        pub aura: Spin,
         pub grandpa: Grandpa,
     }
 }
@@ -76,7 +76,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 mod block_times {
     /// This determines the average expected block time that we are targeting. Blocks will be
     /// produced at a minimum duration defined by `SLOT_DURATION`. `SLOT_DURATION` is picked up by
-    /// `pallet_timestamp` which is in turn picked up by `pallet_aura` to implement `fn
+    /// `pallet_timestamp` which is in turn picked up by `pallet_spin` to implement `fn
     /// slot_duration()`.
     ///
     /// Change this to adjust the block time.
@@ -206,8 +206,9 @@ mod runtime {
     #[runtime::pallet_index(1)]
     pub type Timestamp = pallet_timestamp;
 
-    #[runtime::pallet_index(2)]
-    pub type Aura = pallet_aura;
+    /// Aura was used at index 2
+    #[runtime::pallet_index(12)]
+    pub type Spin = pallet_spin;
 
     #[runtime::pallet_index(3)]
     pub type Grandpa = pallet_grandpa;


### PR DESCRIPTION
- first commit clones `pallet-aura`
- second one adds session length storage and an extrinsic for changing it
- also `pallet-spin` now replaces `pallet-aura` completely in the runtime (this will probably require a devnet reset)