### PR TITLE
Fix broken documentation links with markdown-link-check

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![GitHub commit activity](https://img.shields.io/github/commit-activity/m/QuantumFusion-network/qf-solochain)
 ![GitHub last commit](https://img.shields.io/github/last-commit/QuantumFusion-network/qf-solochain)
 <br>
-[![Twitter URL](https://img.shields.io/twitter/follow/QuantumFusion_?style=social)](https://x.com/QuantumFusion_)
+[![Twitter URL](https://img.shields.io/twitter/follow/theqfnetwork?style=social)](https://x.com/theqfnetwork)
 
 </div>
 

--- a/parachain/README.md
+++ b/parachain/README.md
@@ -47,8 +47,8 @@ such as a [Balances pallet](https://paritytech.github.io/polkadot-sdk/master/pal
 
 A Polkadot SDK based project such as this one consists of:
 
-- 🧮 the [Runtime](./runtime/README.md) - the core logic of the parachain.
-- 🎨 the [Pallets](./pallets/README.md) - from which the runtime is constructed.
+- 🧮 the [Runtime](/runtimes/parachain/README.md) - the core logic of the parachain.
+- 🎨 the [Pallets](/pallets) - from which the runtime is constructed.
 - 💿 a [Node](./node/README.md) - the binary application, not part of the project default-members list and not compiled unless
 building the project with `--workspace` flag, which builds all workspace members, and is an alternative to
 [Omni Node](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/reference_docs/omni_node/index.html).

--- a/parachain/node/README.md
+++ b/parachain/node/README.md
@@ -1,6 +1,6 @@
 # Node
 
-ℹ️ A node -  in Polkadot - is a binary executable, whose primary purpose is to execute the [runtime](../runtime/README.md).
+ℹ️ A node -  in Polkadot - is a binary executable, whose primary purpose is to execute the [runtime](/runtimes/parachain/README.md).
 
 🔗 It communicates with other nodes in the network, and aims for
 [consensus](https://wiki.polkadot.network/docs/learn-consensus) among them.

--- a/runtimes/parachain/README.md
+++ b/runtimes/parachain/README.md
@@ -4,7 +4,7 @@
 responsible for validating blocks and executing the state changes they define.
 
 💁 The runtime in this template is constructed using ready-made FRAME pallets that ship with
-[Polkadot SDK](https://github.com/paritytech/polkadot-sdk), and a [template for a custom pallet](../pallets/README.md).
+[Polkadot SDK](https://github.com/paritytech/polkadot-sdk), and a [template for a custom pallet](https://github.com/paritytech/polkadot-sdk-parachain-template/blob/master/pallets/README.md).
 
 👉 Learn more about FRAME
 [here](https://paritytech.github.io/polkadot-sdk/master/polkadot_sdk_docs/polkadot_sdk/frame_runtime/index.html).


### PR DESCRIPTION
Fixes: [#462](https://github.com/QuantumFusion-network/spec/issues/462)
Used: https://github.com/tcort/markdown-link-check

```console
$ docker run -v $PWD:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable -p -i /tmp/target -i /tmp/vendor/polkavm /tmp

FILE: /tmp/README.md
  [✓] https://github.com/QuantumFusion-network/qf-solochain/blob/main/LICENSE
  [✖] https://x.com/QuantumFusion_
  [✓] #contributing
  [✓] https://learn.microsoft.com/en-us/windows/wsl/install

<snip>
```