### PR TITLE
Skip irrelevant checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,8 +40,8 @@ jobs:
         if: steps.filter.outputs.markdown == 'true'
         uses: DavidAnson/markdownlint-cli2-action@v19
         with:
-          config: '.markdownlint.yaml'
-          globs: '**/*.md'
+          config: ".markdownlint.yaml"
+          globs: "**/*.md"
 
       - name: Skip - no Rust files changed
         if: steps.filter.outputs.rust != 'true'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force running all checks'
+        required: false
+        default: 'false'
 
 jobs:
   files-changed:
@@ -33,7 +38,7 @@ jobs:
               - '**/*.toml'
 
   markdown:
-    if: needs.files-changed.outputs.markdown == 'true'
+    if: needs.files-changed.outputs.markdown == 'true' || github.event.inputs.force == 'true'
     needs: files-changed
     name: Check Markdown
     runs-on: [self-hosted]
@@ -50,11 +55,10 @@ jobs:
           globs: "**/*.md"
 
   rust:
-    if: needs.files-changed.outputs.rust == 'true'
+    if: needs.files-changed.outputs.rust == 'true' || github.event.inputs.force == 'true'
     needs: files-changed
     name: Check Rust
     runs-on: [self-hosted]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  cargo-check:
-    name: Cargo Check
+  checks:
+    name: Checks
     runs-on: [self-hosted]
 
     steps:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,6 +36,8 @@ jobs:
               - '**/*.lock'
               - '**/*.rs'
               - '**/*.toml'
+              - Makefile
+              - node/src/res/*.json
 
   markdown:
     if: needs.files-changed.outputs.markdown == 'true' || github.event.inputs.force == 'true'

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,13 +21,33 @@ jobs:
         # with:
         #   submodules: recursive
 
+      - name: Detect changed file types
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            markdown:
+              - .markdownlint.yaml
+              - '**/*.md'
+            rust:
+              - '**/*.lock'
+              - '**/*.rs'
+              - '**/*.toml'
+
       # Update files to resolve fixable issues:
       # `markdownlint-cli2 "**/*.md" "#target" "#vendor" --config .markdownlint.yaml --fix`.
       - name: Check Markdown
+        if: steps.filter.outputs.markdown == 'true'
         uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           config: '.markdownlint.yaml'
           globs: '**/*.md'
+
+      - name: Skip - no Rust files changed
+        if: steps.filter.outputs.rust != 'true'
+        run: |
+          echo "No Rust files changed. Skipping further steps."
+          exit 0
 
       - run: |
           make vendor-clone

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,21 +9,19 @@ on:
   workflow_dispatch:
 
 jobs:
-  checks:
-    name: Checks
+  files-changed:
+    name: Detect what files changed
     runs-on: [self-hosted]
-
+    outputs:
+      markdown: ${{ steps.filter.outputs.markdown }}
+      rust: ${{ steps.filter.outputs.rust }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        # This is supposed to download submodules, but it doesn't actually work, so we're using
-        # `make vendor-clone` with `git clone ...` instead.
-        # with:
-        #   submodules: recursive
 
       - name: Detect changed file types
-        id: filter
         uses: dorny/paths-filter@v3
+        id: filter
         with:
           filters: |
             markdown:
@@ -34,20 +32,36 @@ jobs:
               - '**/*.rs'
               - '**/*.toml'
 
+  markdown:
+    if: needs.files-changed.outputs.markdown == 'true'
+    needs: files-changed
+    name: Check Markdown
+    runs-on: [self-hosted]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       # Update files to resolve fixable issues:
       # `markdownlint-cli2 "**/*.md" "#target" "#vendor" --config .markdownlint.yaml --fix`.
       - name: Check Markdown
-        if: steps.filter.outputs.markdown == 'true'
         uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           config: ".markdownlint.yaml"
           globs: "**/*.md"
 
-      - name: Skip - no Rust files changed
-        if: steps.filter.outputs.rust != 'true'
-        run: |
-          echo "No Rust files changed. Skipping further steps."
-          exit 0
+  rust:
+    if: needs.files-changed.outputs.rust == 'true'
+    needs: files-changed
+    name: Check Rust
+    runs-on: [self-hosted]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        # This is supposed to download submodules, but it doesn't actually work, so we're using
+        # `make vendor-clone` with `git clone ...` instead.
+        # with:
+        #   submodules: recursive
 
       - run: |
           make vendor-clone


### PR DESCRIPTION
Check Markdown files only when  files changed (or linter's configuration). Run cargo checks only when Rust project files changed. Allow filters bypass if necessary when running the workflow manually, e.g., to run all jobs when the workflow file changed.

See https://github.com/QuantumFusion-network/qf-solochain/pull/123 to verify that it runs Rust checks if an `*.rs` file changed.

Closes https://github.com/QuantumFusion-network/spec/issues/465.