### PR TITLE
Always check main

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,7 @@ jobs:
               - node/src/res/*.json
 
   markdown:
-    if: needs.files-changed.outputs.markdown == 'true' || github.event.inputs.force == 'true'
+    if: needs.files-changed.outputs.markdown == 'true' || github.event.inputs.force == 'true' || github.ref == 'refs/heads/main'
     needs: files-changed
     name: Check Markdown
     runs-on: [self-hosted]
@@ -57,7 +57,7 @@ jobs:
           globs: "**/*.md"
 
   rust:
-    if: needs.files-changed.outputs.rust == 'true' || github.event.inputs.force == 'true'
+    if: needs.files-changed.outputs.rust == 'true' || github.event.inputs.force == 'true' || github.ref == 'refs/heads/main'
     needs: files-changed
     name: Check Rust
     runs-on: [self-hosted]


### PR DESCRIPTION
Otherwise it skips jobs a push to the `main` too, see https://github.com/QuantumFusion-network/qf-solochain/actions/runs/16623766102/job/47034521636. 

Related to https://github.com/QuantumFusion-network/spec/issues/465.