### PR TITLE
Enable asset ID auto increment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12459,7 +12459,7 @@ dependencies = [
 
 [[package]]
 name = "qf-node"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -12539,7 +12539,7 @@ dependencies = [
 
 [[package]]
 name = "qf-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qf-node"
 description = "QF Network solochain node"
-version = "0.1.17"
+version = "0.1.18"
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -122,6 +122,9 @@ fn testnet_genesis(
 	const STASH: u128 = 10u128.pow(5) * qf_runtime::UNIT;
 
 	serde_json::json!({
+		"assets": {
+			"nextAssetId": Some(1),
+		},
 		"balances": {
 			"balances": endowed_accounts.iter().cloned().map(|k| (k, ENDOWMENT)).collect::<Vec<_>>(),
 		},

--- a/runtimes/qf-runtime/Cargo.toml
+++ b/runtimes/qf-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "qf-runtime"
 description = "QF Network solochain runtime"
-version = "0.5.0"
+version = "0.5.1"
 license.workspace = true
 authors.workspace = true
 homepage.workspace = true

--- a/runtimes/qf-runtime/src/configs/mod.rs
+++ b/runtimes/qf-runtime/src/configs/mod.rs
@@ -136,7 +136,7 @@ impl pallet_assets::Config for Runtime {
 	type Holder = ();
 	type Extra = ();
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
-	type CallbackHandle = (); // TODO(khssnv): pallet_assets::AutoIncAssetId?
+	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime>;
 	type AssetAccountDeposit = AssetAccountDeposit;
 	type RemoveItemsLimit = RemoveItemsLimit;
 	#[cfg(feature = "runtime-benchmarks")]

--- a/runtimes/qf-runtime/src/lib.rs
+++ b/runtimes/qf-runtime/src/lib.rs
@@ -67,7 +67,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	// runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	// `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 102,
+	spec_version: 103,
 	impl_version: 1,
 	apis: apis::RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtimes/qf-runtime/src/lib.rs
+++ b/runtimes/qf-runtime/src/lib.rs
@@ -20,6 +20,7 @@ use sp_runtime::{
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+pub use frame_support::traits::ConstU32;
 pub use frame_system::Call as SystemCall;
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
@@ -194,7 +195,7 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, TxExtension>;
 ///
 /// This can be a tuple of types, each implementing `OnRuntimeUpgrade`.
 #[allow(unused_parens)]
-type Migrations = ();
+type Migrations = (pallet_assets::migration::next_asset_id::SetNextAssetId<ConstU32<1>, Runtime>,);
 
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<


### PR DESCRIPTION
Enforce sequential asset IDs and make the next ID readable from the chain state.

Related to https://github.com/QuantumFusion-network/spec/issues/563.